### PR TITLE
[#3] 식별자 리스트를 통한 퀴즈 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/quizit/backend/domain/quiz/handler/QuizHandler.kt
+++ b/src/main/kotlin/com/quizit/backend/domain/quiz/handler/QuizHandler.kt
@@ -62,9 +62,22 @@ class QuizHandler(
         ServerResponse.ok()
             .body(quizService.getQuizzesByQuestionContains(request.queryParamNotNull("question")))
 
-    fun getMarkedQuizzes(request: ServerRequest): Mono<ServerResponse> =
-        ServerResponse.ok()
-            .body(quizService.getMarkedQuizzes(request.pathVariable("id")))
+    fun getQuizzesByIdsIn(request: ServerRequest): Mono<ServerResponse> =
+        with(request) {
+            bodyToMono<List<String>>()
+                .flatMap {
+                    ServerResponse.ok()
+                        .body(
+                            quizService.getQuizzesByIdsIn(
+                                it,
+                                PageRequest.of(
+                                    queryParamNotNull<Int>("page"),
+                                    queryParamNotNull<Int>("size")
+                                )
+                            )
+                        )
+                }
+        }
 
     fun createQuiz(request: ServerRequest): Mono<ServerResponse> =
         with(request) {

--- a/src/main/kotlin/com/quizit/backend/domain/quiz/repository/QuizRepository.kt
+++ b/src/main/kotlin/com/quizit/backend/domain/quiz/repository/QuizRepository.kt
@@ -13,12 +13,12 @@ interface QuizRepository : ReactiveMongoRepository<Quiz, String> {
 
     fun findAllByWriterId(writerId: String): Flux<Quiz>
 
-    fun findAllByIdIn(ids: List<String>): Flux<Quiz>
+    fun findAllByIdIn(ids: List<String>, pageable: Pageable): Flux<Quiz>
 
     fun findAllByQuestionContains(keyword: String): Flux<Quiz>
 
     fun findAllByCurriculumId(curriculumId: String): Flux<Quiz>
-    
+
     fun findAllByCourseId(courseId: String): Flux<Quiz>
 
     @Query("{'chapterId': ?0,'answerRate': {'\$gte': ?1, '\$lte': ?2 } }")

--- a/src/main/kotlin/com/quizit/backend/domain/quiz/router/QuizRouter.kt
+++ b/src/main/kotlin/com/quizit/backend/domain/quiz/router/QuizRouter.kt
@@ -27,7 +27,7 @@ class QuizRouter {
                 GET("/writer/{id}", handler::getQuizzesByWriterId)
                 GET("/{id}/mark", handler::markQuiz)
                 GET("/{id}/evaluate", queryParams("isLike"), handler::evaluateQuiz)
-                GET("/marked-user/{id}", handler::getMarkedQuizzes)
+                POST("/ids", queryParams("page", "size"), handler::getQuizzesByIdsIn)
                 POST("", handler::createQuiz)
                 POST("/{id}/check", handler::checkAnswer)
                 POST("/{id}/evaluate", handler::evaluateQuiz)

--- a/src/main/kotlin/com/quizit/backend/domain/quiz/service/QuizService.kt
+++ b/src/main/kotlin/com/quizit/backend/domain/quiz/service/QuizService.kt
@@ -64,9 +64,8 @@ class QuizService(
         quizRepository.findAllByQuestionContains(keyword)
             .map { QuizResponse(it) }
 
-    fun getMarkedQuizzes(userId: String): Flux<QuizResponse> =
-        userRepository.findById(userId)
-            .flatMapMany { quizRepository.findAllByIdIn(it.markedQuizIds.toList()) }
+    fun getQuizzesByIdsIn(ids: List<String>, pageable: Pageable): Flux<QuizResponse> =
+        quizRepository.findAllByIdIn(ids, pageable)
             .map { QuizResponse(it) }
 
     fun createQuiz(userId: String, request: CreateQuizRequest): Mono<QuizResponse> =

--- a/src/test/kotlin/com/quizit/backend/controller/QuizControllerTest.kt
+++ b/src/test/kotlin/com/quizit/backend/controller/QuizControllerTest.kt
@@ -273,21 +273,26 @@ class QuizControllerTest : ControllerTest() {
             }
         }
 
-        describe("getMarkedQuizzes()는") {
-            context("유저가 저장한 퀴즈가 존재하는 경우") {
-                every { quizService.getMarkedQuizzes(any()) } returns listOf(createQuizResponse())
+        describe("getQuizzesByIdsIn()는") {
+            context("퀴즈들이 존재하는 경우") {
+                every { quizService.getQuizzesByIdsIn(any(), any()) } returns listOf(createQuizResponse())
                 withMockUser()
 
                 it("상태 코드 200과 quizResponse들을 반환한다.") {
                     webClient
-                        .get()
-                        .uri("/quiz/marked-user/{id}", ID)
+                        .post()
+                        .uri("/quiz/ids?page={page}&size={size}", 0, 1)
+                        .bodyValue(listOf(ID))
                         .exchange()
                         .expectStatus()
                         .isOk
                         .expectBody<List<QuizResponse>>()
                         .document(
-                            "유저가 저장한 퀴즈 전체 조회 성공(200)",
+                            "식별자 리스트를 통한 퀴즈 전체 조회 성공(200)",
+                            queryParameters(
+                                "page" paramDesc "페이지 번호",
+                                "size" paramDesc "페이지 크기",
+                            ),
                             responseFields(quizResponseFields.toListFields())
                         )
                 }

--- a/src/test/kotlin/com/quizit/backend/service/QuizServiceTest.kt
+++ b/src/test/kotlin/com/quizit/backend/service/QuizServiceTest.kt
@@ -44,7 +44,7 @@ class QuizServiceTest : BehaviorSpec() {
                 .also {
                     every { quizRepository.findAllByCourseId(any()) } returns listOf(it)
                     every { quizRepository.findAllByChapterId(any()) } returns listOf(it)
-                    every { quizRepository.findAllByIdIn(any()) } returns listOf(it)
+                    every { quizRepository.findAllByIdIn(any(), any()) } returns listOf(it)
                     every { quizRepository.findAllByQuestionContains(any()) } returns listOf(it)
                     every {
                         quizRepository.findAllByChapterIdAndAnswerRateBetween(any(), any(), any(), any())
@@ -120,6 +120,17 @@ class QuizServiceTest : BehaviorSpec() {
                 }
             }
 
+            When("특정 식별자 리스트에 속한 퀴즈들을 조회하면") {
+                val result = quizService.getQuizzesByIdsIn(listOf(ID), PAGEABLE)
+                    .getResult()
+
+                Then("해당 식별자 리스트에 속하는 퀴즈들이 주어진다.") {
+                    result.expectSubscription()
+                        .expectNext(quizResponse)
+                        .verifyComplete()
+                }
+            }
+
             When("유저가 특정 퀴즈를 수정하면") {
                 val updateQuizByIdRequest = createUpdateQuizByIdRequest(question = "updated_question")
                     .also {
@@ -141,30 +152,6 @@ class QuizServiceTest : BehaviorSpec() {
 
                 Then("해당 퀴즈가 삭제된다.") {
                     result.expectSubscription()
-                        .verifyComplete()
-                }
-            }
-        }
-
-        Given("유저가 저장한 퀴즈가 존재하는 경우") {
-            val quiz = createQuiz()
-                .also {
-                    every { quizRepository.findAllByIdIn(any()) } returns listOf(it)
-                }
-            createUser()
-                .also {
-                    every { userRepository.findById(any<String>()) } returns it
-                }
-
-            val quizResponse = QuizResponse(quiz)
-
-            When("유저가 본인이 저장한 퀴즈 보관함에 들어가면") {
-                val result = quizService.getMarkedQuizzes(ID)
-                    .getResult()
-
-                Then("유저가 저장한 퀴즈들이 주어진다.") {
-                    result.expectSubscription()
-                        .expectNext(quizResponse)
                         .verifyComplete()
                 }
             }


### PR DESCRIPTION
## 작업 내용

* **기존의 저장한 퀴즈들 조회 기능 삭제**
* **식별자 리스트를 통한 퀴즈 조회 기능 구현**

## 관련 이슈

* **Close #3**